### PR TITLE
Remove ssize_t due to its complexity

### DIFF
--- a/src/curlws.c
+++ b/src/curlws.c
@@ -337,6 +337,8 @@ CWScode cws_send_blk_binary(CWS *priv, const void *data, size_t len)
 
 CWScode cws_send_blk_text(CWS *priv, const char *s, size_t len)
 {
+    size_t prev_len;
+
     if (s) {
         if (len == SIZE_MAX) {
             len = strlen(s);
@@ -345,7 +347,8 @@ CWScode cws_send_blk_text(CWS *priv, const char *s, size_t len)
         len = 0;
     }
 
-    if (((ssize_t) len) != utf8_validate(s, len)) {
+    prev_len = len;
+    if (0 != utf8_validate(s, &len) || (prev_len != len)) {
         return CWSE_INVALID_UTF8;
     }
 
@@ -365,12 +368,12 @@ CWScode cws_send_strm_binary(CWS *priv, int info, const void *data, size_t len)
 
 CWScode cws_send_strm_text(CWS *priv, int info, const char *s, size_t len)
 {
+    size_t prev_len = len;
+
     IGNORE_UNUSED(priv);
     IGNORE_UNUSED(info);
-    IGNORE_UNUSED(s);
-    IGNORE_UNUSED(len);
 
-    if (((ssize_t) len) != utf8_validate(s, len)) {
+    if (0 != utf8_validate(s, &len) || (prev_len != len)) {
         return CWSE_INVALID_UTF8;
     }
 
@@ -409,7 +412,8 @@ static CWScode _normalize_close_inputs(int *_code, int *_opts,
         }
 
         if (0 < len) {
-            if (((ssize_t) len) != utf8_validate(reason, len)) {
+            size_t prev_len = len;
+            if (0 != utf8_validate(reason, &len) || (prev_len != len)) {
                 return CWSE_INVALID_UTF8;
             }
 

--- a/src/frame.c
+++ b/src/frame.c
@@ -48,7 +48,7 @@
 /*----------------------------------------------------------------------------*/
 /*                             Function Prototypes                            */
 /*----------------------------------------------------------------------------*/
-static int _frame_decode(struct cws_frame*, const void*, size_t, ssize_t*);
+static int _frame_decode(struct cws_frame*, const void*, size_t, long*);
 
 /*----------------------------------------------------------------------------*/
 /*                             External Functions                             */
@@ -103,10 +103,10 @@ int frame_validate(const struct cws_frame *f, frame_dir dir)
 }
 
 
-int frame_decode(struct cws_frame *in, const void *buffer, size_t len, ssize_t *delta)
+int frame_decode(struct cws_frame *in, const void *buffer, size_t len, long *delta)
 {
     if (NULL == delta) {
-        ssize_t tmp;
+        long tmp;
         return _frame_decode(in, buffer, len, &tmp);
     }
     return _frame_decode(in, buffer, len, delta);
@@ -214,7 +214,7 @@ const char* frame_opcode_to_string(const struct cws_frame *f)
 /*----------------------------------------------------------------------------*/
 /*                             Internal functions                             */
 /*----------------------------------------------------------------------------*/
-static int _frame_decode(struct cws_frame *in, const void *buffer, size_t len, ssize_t *delta)
+static int _frame_decode(struct cws_frame *in, const void *buffer, size_t len, long *delta)
 {
     struct cws_frame f;
     const uint8_t *buf = (const uint8_t*) buffer;

--- a/src/frame.h
+++ b/src/frame.h
@@ -94,7 +94,7 @@ int frame_validate(const struct cws_frame *f, frame_dir dir);
  *         -4 length field was too large
  *         -5 length field was too small (<65536) for the length field size
  */
-int frame_decode(struct cws_frame *f, const void *buf, size_t len, ssize_t *delta);
+int frame_decode(struct cws_frame *f, const void *buf, size_t len, long *delta);
 
 
 /**

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -108,7 +108,7 @@ size_t utf8_get_size(char c)
 bool utf8_maybe_valid(const char *text, size_t len)
 {
     char buf[4] = { 0, 0x80, 0x80, 0x80 };
-    ssize_t c_len;
+    size_t c_len;
 
     memcpy(buf, text, len);
     c_len = utf8_len[(uint8_t)*buf];
@@ -117,7 +117,7 @@ bool utf8_maybe_valid(const char *text, size_t len)
         return false;
     }
 
-    if (c_len == utf8_validate(buf, c_len)) {
+    if (0 == utf8_validate(buf, &c_len)) {
         return true;
     }
 
@@ -125,16 +125,17 @@ bool utf8_maybe_valid(const char *text, size_t len)
 }
 
 
-ssize_t utf8_validate(const char *text, size_t len)
+int utf8_validate(const char *text, size_t *len)
 {
     const uint8_t *bytes = (const uint8_t*) text;
-    size_t left = len;
+    size_t left = *len;
 
     while (left) {
         size_t c_len = utf8_len[*bytes];
 
         if (left < c_len) {
-            return len - left;
+            *len -= left;
+            return 0;
         }
 
         if (0 == c_len) {
@@ -176,7 +177,8 @@ ssize_t utf8_validate(const char *text, size_t len)
         bytes += c_len;
     }
 
-    return len - left;
+    *len -= left;
+    return 0;
 }
 
 

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -58,20 +58,18 @@ bool utf8_maybe_valid(const char *text, size_t len);
 
 
 /**
- * Checks a string to ensure only valid UTF8 character sequences are present
+ * Checks a string to ensure only valid UTF-8 character sequences are present
  * and returns the number of bytes left over (of there are any).
  *
- * @param string the text to validate is UTF8
- * @param len    the length of the string in bytes
+ * @param text   the string to validate is UTF-8
+ * @param len    the length of the string in bytes (in)
+ *               the length of the string in bytes of all completely present
+ *               characters (out)
  *
- * @returns 0 or greater if all the characters so far are valid.  If the return
- *          value is less than the len, then there are extra utf8 bytes that are
- *          not enough to make the next character.  The caller needs to deal
- *          with them.
- *
- *          If less than 0 then there was an encoding error.
+ * @returns 0 if the string is valid assuming more data may come later, or
+ *          less than zero indicates an error 
  */
-ssize_t utf8_validate(const char *text, size_t len);
+int utf8_validate(const char *text, size_t *len);
 
 #endif
 

--- a/tests/test_utf8.c
+++ b/tests/test_utf8.c
@@ -34,66 +34,67 @@
 void test_utf8()
 {
     struct t {
-        ssize_t expect;
+        int rv;
+        size_t expect;
         size_t len;
         const char *data;
     } tests[] = {
-        { .expect =  1, .len = 1, .data = "\x00"                }, /* 0x0000 */
-        { .expect =  1, .len = 1, .data = "\x01"                }, /* 0x0001 */
-        { .expect =  1, .len = 1, .data = "\x7e"                }, /* 0x007e */
-        { .expect =  1, .len = 1, .data = "\x7f"                }, /* 0x007f */
-        { .expect = -1, .len = 1, .data = "\x80"                }, /* invalid 0x0080 */
-        { .expect = -1, .len = 1, .data = "\x81"                }, /* invalid 0x0081 */
-        { .expect = -1, .len = 2, .data = "\xc1\xbf"            }, /* invalid 0x007f */
-        { .expect =  2, .len = 2, .data = "\xc2\x80"            }, /* 0x0080 */
-        { .expect =  2, .len = 2, .data = "\xc2\x81"            }, /* 0x0081 */
-        { .expect =  2, .len = 2, .data = "\xc3\x88"            }, /* 0x00c8 */
-        { .expect =  2, .len = 2, .data = "\xc3\x90"            }, /* 0x00d0 */
-        { .expect =  2, .len = 2, .data = "\xc3\xa0"            }, /* 0x00e0 */
-        { .expect =  2, .len = 2, .data = "\xc3\xb0"            }, /* 0x00f0 */
-        { .expect =  2, .len = 2, .data = "\xc3\xb8"            }, /* 0x00f8 */
-        { .expect =  2, .len = 2, .data = "\xc3\xbf"            }, /* 0x00ff */
-        { .expect =  2, .len = 2, .data = "\xc4\x80"            }, /* 0x0100 */
-        { .expect =  2, .len = 2, .data = "\xd0\x80"            }, /* 0x0400 */
-        { .expect =  2, .len = 2, .data = "\xdf\xbf"            }, /* 0x07ff */
-        { .expect = -1, .len = 3, .data = "\xe0\x9f\xbf"        }, /* invalid 0x07ff */
-        { .expect =  3, .len = 3, .data = "\xe0\xa0\x80"        }, /* 0x0800 */
-        { .expect =  3, .len = 3, .data = "\xe0\xa0\x81"        }, /* 0x0801 */
-        { .expect =  3, .len = 3, .data = "\xe1\x80\x80"        }, /* 0x1000 */
-        { .expect =  3, .len = 3, .data = "\xed\x80\x80"        }, /* 0xd000 */
-        { .expect =  3, .len = 3, .data = "\xed\x9f\xbf"        }, /* 0xd7ff */
-        { .expect = -1, .len = 3, .data = "\xed\xa0\x80"        }, /* invalid 0xd800 */
-        { .expect = -1, .len = 3, .data = "\xed\xbf\xbf"        }, /* invalid 0xdfff */
-        { .expect =  3, .len = 3, .data = "\xee\x80\x80"        }, /* 0xe000 */
-        { .expect =  3, .len = 3, .data = "\xef\xbf\xbe"        }, /* 0xfffe */
-        { .expect =  3, .len = 3, .data = "\xef\xbf\xbf"        }, /* 0xffff */
-        { .expect = -1, .len = 4, .data = "\xf0\x8f\xbf\xbf"    }, /* invalid 0xffff */
-        { .expect =  4, .len = 4, .data = "\xf0\x90\x80\x80"    }, /* 0x10000 */
-        { .expect =  4, .len = 4, .data = "\xf0\x90\x80\x81"    }, /* 0x10001 */
-        { .expect =  4, .len = 4, .data = "\xf1\x80\x80\x80"    }, /* 0x40000 */
-        { .expect =  4, .len = 4, .data = "\xf4\x8f\xbf\xbe"    }, /* 0x10fffe */
-        { .expect =  4, .len = 4, .data = "\xf4\x8f\xbf\xbf"    }, /* 0x10ffff */
-        { .expect = -1, .len = 4, .data = "\xf4\xa0\x80\x80"    }, /* invalid 0x110000 */
-        { .expect =  3, .len = 3, .data = "\xef\xbf\xbd"        }, /* 0xFFFD */
-        { .expect =  0, .len = 3, .data = "\xf4\x8f\xbf\xbf"    }, /* too short 0x10ffff */
-        { .expect = -1, .len = 2, .data = "\xc2\xff"            }, /* invalid 2nd char */
-        { .expect = -1, .len = 3, .data = "\xe2\x00\x80"        }, /* invalid 2nd char */
-        { .expect = -1, .len = 3, .data = "\xe2\x80\x00"        }, /* invalid 3nd char */
-        { .expect = -1, .len = 4, .data = "\xf1\x00\x80\x80"    }, /* invalid 2nd char */
-        { .expect = -1, .len = 4, .data = "\xf1\x80\x00\x80"    }, /* invalid 3nd char */
-        { .expect = -1, .len = 4, .data = "\xf1\x80\x80\x00"    }, /* invalid 4th char */
+        { .rv =  0, .expect =  1, .len = 1, .data = "\x00"                }, /* 0x0000 */
+        { .rv =  0, .expect =  1, .len = 1, .data = "\x01"                }, /* 0x0001 */
+        { .rv =  0, .expect =  1, .len = 1, .data = "\x7e"                }, /* 0x007e */
+        { .rv =  0, .expect =  1, .len = 1, .data = "\x7f"                }, /* 0x007f */
+        { .rv = -1, .expect =  1, .len = 1, .data = "\x80"                }, /* invalid 0x0080 */
+        { .rv = -1, .expect =  1, .len = 1, .data = "\x81"                }, /* invalid 0x0081 */
+        { .rv = -1, .expect =  2, .len = 2, .data = "\xc1\xbf"            }, /* invalid 0x007f */
+        { .rv =  0, .expect =  2, .len = 2, .data = "\xc2\x80"            }, /* 0x0080 */
+        { .rv =  0, .expect =  2, .len = 2, .data = "\xc2\x81"            }, /* 0x0081 */
+        { .rv =  0, .expect =  2, .len = 2, .data = "\xc3\x88"            }, /* 0x00c8 */
+        { .rv =  0, .expect =  2, .len = 2, .data = "\xc3\x90"            }, /* 0x00d0 */
+        { .rv =  0, .expect =  2, .len = 2, .data = "\xc3\xa0"            }, /* 0x00e0 */
+        { .rv =  0, .expect =  2, .len = 2, .data = "\xc3\xb0"            }, /* 0x00f0 */
+        { .rv =  0, .expect =  2, .len = 2, .data = "\xc3\xb8"            }, /* 0x00f8 */
+        { .rv =  0, .expect =  2, .len = 2, .data = "\xc3\xbf"            }, /* 0x00ff */
+        { .rv =  0, .expect =  2, .len = 2, .data = "\xc4\x80"            }, /* 0x0100 */
+        { .rv =  0, .expect =  2, .len = 2, .data = "\xd0\x80"            }, /* 0x0400 */
+        { .rv =  0, .expect =  2, .len = 2, .data = "\xdf\xbf"            }, /* 0x07ff */
+        { .rv = -1, .expect =  3, .len = 3, .data = "\xe0\x9f\xbf"        }, /* invalid 0x07ff */
+        { .rv =  0, .expect =  3, .len = 3, .data = "\xe0\xa0\x80"        }, /* 0x0800 */
+        { .rv =  0, .expect =  3, .len = 3, .data = "\xe0\xa0\x81"        }, /* 0x0801 */
+        { .rv =  0, .expect =  3, .len = 3, .data = "\xe1\x80\x80"        }, /* 0x1000 */
+        { .rv =  0, .expect =  3, .len = 3, .data = "\xed\x80\x80"        }, /* 0xd000 */
+        { .rv =  0, .expect =  3, .len = 3, .data = "\xed\x9f\xbf"        }, /* 0xd7ff */
+        { .rv = -1, .expect =  3, .len = 3, .data = "\xed\xa0\x80"        }, /* invalid 0xd800 */
+        { .rv = -1, .expect =  3, .len = 3, .data = "\xed\xbf\xbf"        }, /* invalid 0xdfff */
+        { .rv =  0, .expect =  3, .len = 3, .data = "\xee\x80\x80"        }, /* 0xe000 */
+        { .rv =  0, .expect =  3, .len = 3, .data = "\xef\xbf\xbe"        }, /* 0xfffe */
+        { .rv =  0, .expect =  3, .len = 3, .data = "\xef\xbf\xbf"        }, /* 0xffff */
+        { .rv = -1, .expect =  4, .len = 4, .data = "\xf0\x8f\xbf\xbf"    }, /* invalid 0xffff */
+        { .rv =  0, .expect =  4, .len = 4, .data = "\xf0\x90\x80\x80"    }, /* 0x10000 */
+        { .rv =  0, .expect =  4, .len = 4, .data = "\xf0\x90\x80\x81"    }, /* 0x10001 */
+        { .rv =  0, .expect =  4, .len = 4, .data = "\xf1\x80\x80\x80"    }, /* 0x40000 */
+        { .rv =  0, .expect =  4, .len = 4, .data = "\xf4\x8f\xbf\xbe"    }, /* 0x10fffe */
+        { .rv =  0, .expect =  4, .len = 4, .data = "\xf4\x8f\xbf\xbf"    }, /* 0x10ffff */
+        { .rv = -1, .expect =  4, .len = 4, .data = "\xf4\xa0\x80\x80"    }, /* invalid 0x110000 */
+        { .rv =  0, .expect =  3, .len = 3, .data = "\xef\xbf\xbd"        }, /* 0xFFFD */
+        { .rv =  0, .expect =  0, .len = 3, .data = "\xf4\x8f\xbf\xbf"    }, /* too short 0x10ffff */
+        { .rv = -1, .expect =  2, .len = 2, .data = "\xc2\xff"            }, /* invalid 2nd char */
+        { .rv = -1, .expect =  3, .len = 3, .data = "\xe2\x00\x80"        }, /* invalid 2nd char */
+        { .rv = -1, .expect =  3, .len = 3, .data = "\xe2\x80\x00"        }, /* invalid 3nd char */
+        { .rv = -1, .expect =  4, .len = 4, .data = "\xf1\x00\x80\x80"    }, /* invalid 2nd char */
+        { .rv = -1, .expect =  4, .len = 4, .data = "\xf1\x80\x00\x80"    }, /* invalid 3nd char */
+        { .rv = -1, .expect =  4, .len = 4, .data = "\xf1\x80\x80\x00"    }, /* invalid 4th char */
 
-        { .expect = 14, .len = 14, .data = "a\xc2\x80\xe8\x80\x80\xf1\x80\x80\x80\xf1\xbf\xbf\xbf" },
+        { .rv =  0, .expect = 14, .len = 14, .data = "a\xc2\x80\xe8\x80\x80\xf1\x80\x80\x80\xf1\xbf\xbf\xbf" },
     };
 
     for (size_t i = 0; i < sizeof(tests)/sizeof(struct t); i++) {
         struct t *test = &tests[i];
-        ssize_t got;
+        int got;
 
-        got = utf8_validate(test->data, test->len);
-        if (test->expect != got) {
-            printf("%zd - expect: %zd, got: %zd, len: %zd, data: 0x%02x",
-                   i, test->expect, got, test->len, 0xff & test->data[0]);
+        got = utf8_validate(test->data, &test->len);
+        if (test->rv != got) {
+            printf("%zd - rv expected: %d, got: %d, len expected: %zd, len got: %zd, data: 0x%02x",
+                   i, test->rv, got, test->expect, test->len, 0xff & test->data[0]);
             if (1 < test->len) {
                 printf("%02x", 0xff & test->data[1]);
             }
@@ -106,7 +107,8 @@ void test_utf8()
             printf("\n");
         }
         /* Run the test again so it's easier to debug. */
-        CU_ASSERT(test->expect == utf8_validate(test->data, test->len))
+        CU_ASSERT(test->rv == utf8_validate(test->data, &test->len));
+        CU_ASSERT(test->len == test->expect);
     }
 }
 


### PR DESCRIPTION
The definition of what ssize_t can hold is not clear.  As such it is
better to avoid it's use in the code vs. inadvertently using the type
in a non-portable way.