### PR TITLE
Improve the verbose output testing

### DIFF
--- a/src/cb.c
+++ b/src/cb.c
@@ -54,7 +54,8 @@
 void cb_on_connect(CWS *priv, const char *protos)
 {
     if (priv->cfg.verbose) {
-        fprintf(stderr, "< websocket on_connect protos: '%s'\n", protos);
+        fprintf(priv->cfg.verbose_stream,
+                "< websocket on_connect() protos: '%s'\n", protos);
     }
 
     if (priv->cb.on_connect_fn) {
@@ -62,7 +63,7 @@ void cb_on_connect(CWS *priv, const char *protos)
     }
 
     if (priv->cfg.verbose) {
-        fprintf(stderr, "> websocket on_connect\n");
+        fprintf(priv->cfg.verbose_stream, "> websocket on_connect()\n");
     }
 }
 
@@ -70,7 +71,17 @@ void cb_on_connect(CWS *priv, const char *protos)
 void cb_on_text(CWS *priv, const char *text, size_t len)
 {
     if (priv->cfg.verbose) {
-        fprintf(stderr, "< websocket on_text len: %zd, text: '%.*s'\n", len, (int) len, text);
+        int truncated;
+        char *dots = "...";
+
+        truncated = 40;
+        if (len <= (size_t) truncated) {
+            truncated = (int) len;
+            dots = "";
+        }
+        fprintf(priv->cfg.verbose_stream,
+                "< websocket on_text() len: %zd, text: '%.*s%s'\n", len,
+                truncated, text, dots);
     }
 
     if (priv->cb.on_text_fn) {
@@ -78,7 +89,7 @@ void cb_on_text(CWS *priv, const char *text, size_t len)
     }
 
     if (priv->cfg.verbose) {
-        fprintf(stderr, "> websocket on_text\n");
+        fprintf(priv->cfg.verbose_stream, "> websocket on_text()\n");
     }
 }
 
@@ -86,7 +97,8 @@ void cb_on_text(CWS *priv, const char *text, size_t len)
 void cb_on_binary(CWS *priv, const void *buf, size_t len)
 {
     if (priv->cfg.verbose) {
-        fprintf(stderr, "< websocket on_binary len: %zd, [buf]\n", len);
+        fprintf(priv->cfg.verbose_stream,
+                "< websocket on_binary() len: %zd, [buf]\n", len);
     }
 
     if (priv->cb.on_binary_fn) {
@@ -94,7 +106,7 @@ void cb_on_binary(CWS *priv, const void *buf, size_t len)
     }
 
     if (priv->cfg.verbose) {
-        fprintf(stderr, "> websocket on_binary\n");
+        fprintf(priv->cfg.verbose_stream, "> websocket on_binary()\n");
     }
 }
 
@@ -102,7 +114,8 @@ void cb_on_binary(CWS *priv, const void *buf, size_t len)
 void cb_on_fragment(CWS *priv, int info, const void *buf, size_t len)
 {
     if (priv->cfg.verbose) {
-        fprintf(stderr, "< websocket on_fragment info: 0x%08x, len: %zd, [buf]\n", info, len);
+        fprintf(priv->cfg.verbose_stream,
+                "< websocket on_fragment() info: 0x%08x, len: %zd, [buf]\n", info, len);
     }
 
     /* Always present since there is a default handler & clients cannot
@@ -110,7 +123,7 @@ void cb_on_fragment(CWS *priv, int info, const void *buf, size_t len)
     (*priv->cb.on_fragment_fn)(priv->cfg.user, priv, info, buf, len);
 
     if (priv->cfg.verbose) {
-        fprintf(stderr, "> websocket on_fragment\n");
+        fprintf(priv->cfg.verbose_stream, "> websocket on_fragment()\n");
     }
 }
 
@@ -118,7 +131,8 @@ void cb_on_fragment(CWS *priv, int info, const void *buf, size_t len)
 void cb_on_ping(CWS *priv, const void *buf, size_t len)
 {
     if (priv->cfg.verbose) {
-        fprintf(stderr, "< websocket on_ping len: %zd, [buf]\n", len);
+        fprintf(priv->cfg.verbose_stream,
+                "< websocket on_ping() len: %zd, [buf]\n", len);
     }
 
     /* Always present since there is a default handler & clients cannot
@@ -126,7 +140,7 @@ void cb_on_ping(CWS *priv, const void *buf, size_t len)
     (*priv->cb.on_ping_fn)(priv->cfg.user, priv, buf, len);
 
     if (priv->cfg.verbose) {
-        fprintf(stderr, "> websocket on_ping\n");
+        fprintf(priv->cfg.verbose_stream, "> websocket on_ping()\n");
     }
 }
 
@@ -134,7 +148,8 @@ void cb_on_ping(CWS *priv, const void *buf, size_t len)
 void cb_on_pong(CWS *priv, const void *buf, size_t len)
 {
     if (priv->cfg.verbose) {
-        fprintf(stderr, "< websocket on_pong len: %zd, [buf]\n", len);
+        fprintf(priv->cfg.verbose_stream,
+                "< websocket on_pong() len: %zd, [buf]\n", len);
     }
 
     if (priv->cb.on_pong_fn) {
@@ -142,7 +157,7 @@ void cb_on_pong(CWS *priv, const void *buf, size_t len)
     }
 
     if (priv->cfg.verbose) {
-        fprintf(stderr, "> websocket on_pong\n");
+        fprintf(priv->cfg.verbose_stream, "> websocket on_pong()\n");
     }
 }
 
@@ -158,7 +173,7 @@ void cb_on_close(CWS *priv, int code, const char *text, size_t len)
     }
 
     if (priv->cfg.verbose) {
-        fprintf(stderr, "< websocket on_close code: %d, len: %zd, text: '%.*s'\n",
+        fprintf(priv->cfg.verbose_stream, "< websocket on_close() code: %d, len: %zd, text: '%.*s'\n",
                 code, len, (int) len, text);
     }
 
@@ -168,7 +183,7 @@ void cb_on_close(CWS *priv, int code, const char *text, size_t len)
     }
 
     if (priv->cfg.verbose) {
-        fprintf(stderr, "> websocket on_close\n");
+        fprintf(priv->cfg.verbose_stream, "> websocket on_close()\n");
     }
 }
 

--- a/src/curlws.c
+++ b/src/curlws.c
@@ -669,6 +669,7 @@ static int _config_ws_key(CWS *priv)
 
     cws_sha1(combined, strlen(combined), sha1_value);
     cws_encode_base64(sha1_value, sizeof(sha1_value), priv->expected_key_header);
+    priv->expected_key_header_len = strlen(priv->expected_key_header);
 
     return 0;
 }

--- a/src/internal.h
+++ b/src/internal.h
@@ -62,6 +62,7 @@ struct cfg_set {
     /* The stream to log to. */
     FILE *verbose_stream;
 
+    /* The request websocket protocols. */
     char *ws_protocols_requested;
 };
 
@@ -137,6 +138,7 @@ struct cws_object {
 
     /* The key header that the server is expected to return. */
     char expected_key_header[WS_HTTP_EXPECTED_KEY_SIZE];
+    size_t expected_key_header_len;
 
     /* The memory configuration & pool. */
     struct mem_pool_config mem_cfg;

--- a/src/receive.c
+++ b/src/receive.c
@@ -78,12 +78,12 @@ static size_t _writefunction_cb(const char *buffer, size_t count, size_t nitems,
     size_t len = count * nitems;
 
     if (priv->cfg.verbose) {
-        fprintf(stderr, "< websocket bytes received: %ld\n", len);
+        fprintf(priv->cfg.verbose_stream, "< websocket bytes received: %ld\n", len);
     }
 
     if (priv->header_state.redirection) {
         if (priv->cfg.verbose) {
-            fprintf(stderr, "< websocket bytes ignored due to redirection\n");
+            fprintf(priv->cfg.verbose_stream, "< websocket bytes ignored due to redirection\n");
         }
         return len;
     }

--- a/src/send.c
+++ b/src/send.c
@@ -147,7 +147,7 @@ CWScode send_frame(CWS *priv, const struct cws_frame *f)
     }
 
     if (priv->cfg.verbose) {
-        fprintf(stderr, 
+        fprintf(priv->cfg.verbose_stream, 
                 "[ websocket frame queued opcode: %s payload len: %zd ]\n",
                 frame_opcode_to_string(f), f->payload_len);
     }
@@ -159,7 +159,7 @@ CWScode send_frame(CWS *priv, const struct cws_frame *f)
         curl_easy_pause(priv->easy, priv->pause_flags);
 
         if (priv->cfg.verbose) {
-            fprintf(stderr, "[ websocket unpause sending ]\n");
+            fprintf(priv->cfg.verbose_stream, "[ websocket unpause sending ]\n");
         }
     }
     return CWSE_OK;
@@ -245,7 +245,7 @@ static size_t _readfunction_cb(char *buffer, size_t count, size_t n, void *data)
 
     if (priv->header_state.redirection) {
         if (priv->cfg.verbose) {
-            fprintf(stderr, "> websocket %zd bytes ignored due to redirection\n", len);
+            fprintf(priv->cfg.verbose_stream, "> websocket %zd bytes ignored due to redirection\n", len);
         }
         return len;
     }
@@ -255,7 +255,7 @@ static size_t _readfunction_cb(char *buffer, size_t count, size_t n, void *data)
          * shut down the connection. */
         if (priv->closed) {
             if (priv->cfg.verbose) {
-                fprintf(stderr, "> websocket closed by returning 0\n");
+                fprintf(priv->cfg.verbose_stream, "> websocket closed by returning 0\n");
             }
             return 0;
         }
@@ -263,7 +263,7 @@ static size_t _readfunction_cb(char *buffer, size_t count, size_t n, void *data)
         priv->pause_flags |= CURLPAUSE_SEND;
 
         if (priv->cfg.verbose) {
-            fprintf(stderr, "> websocket sending paused\n");
+            fprintf(priv->cfg.verbose_stream, "> websocket sending paused\n");
         }
 
         return CURL_READFUNC_PAUSE;
@@ -272,7 +272,7 @@ static size_t _readfunction_cb(char *buffer, size_t count, size_t n, void *data)
     sent = _fill_outgoing_buffer(priv, buffer, len);
 
     if (priv->cfg.verbose) {
-        fprintf(stderr, "> websocket sent: %ld\n", sent);
+        fprintf(priv->cfg.verbose_stream, "> websocket sent: %ld\n", sent);
     }
 
     return sent;


### PR DESCRIPTION
Now that it's easy to repoint our verbose output to different streams,
use it to enforce the output format for most of the calls.