### PR TITLE
Add tls_version and fix follow_redirects

### DIFF
--- a/examples/cli/cli.c
+++ b/examples/cli/cli.c
@@ -77,6 +77,7 @@ int main(int argc, char *argv[]) {
 
     /* Very simple args parser. */
     for (int i = 1; i < argc; i++) {
+        printf( "arg: '%s'\n", argv[i]);
         if (is_opt(argv[i], "-4", NULL)) {
             cfg.ip_version = 4;
         } else if (is_opt(argv[i], "-6", NULL)) {
@@ -99,6 +100,7 @@ int main(int argc, char *argv[]) {
                    " -L, --location           Follow redirects\n"
                    "     --max-payload <num>  Maximum payload size to send\n"
                    "     --max-redirs <num>   Maximum number of redirects allowed\n"
+                   "     --tlsv1.2            Set the maximum TLS version (useful since Wireshare can only decode tls1.2\n"
                    " -v  --verbose            Verbose debugging in curlws is enabled, repeat for more\n"
                    "     --ws-protos <name>   List of websocket protocols to negotiate\n",
                    argv[0]);
@@ -119,6 +121,8 @@ int main(int argc, char *argv[]) {
         } else if (is_opt(argv[i], NULL, "--max-redirs")) {
             i++;
             max_redirs = atol(argv[i]);
+        } else if (is_opt(argv[i], NULL, "--tlsv1.2")) {
+            cfg.tls_version = CURL_SSLVERSION_MAX_TLSv1_2;
         } else if (is_opt(argv[i], "-v", "--verbose")) {
             cfg.verbose++;
         } else if (is_opt(argv[i], NULL, "--ws_protos")) {

--- a/examples/cli/cli.c
+++ b/examples/cli/cli.c
@@ -77,7 +77,6 @@ int main(int argc, char *argv[]) {
 
     /* Very simple args parser. */
     for (int i = 1; i < argc; i++) {
-        printf( "arg: '%s'\n", argv[i]);
         if (is_opt(argv[i], "-4", NULL)) {
             cfg.ip_version = 4;
         } else if (is_opt(argv[i], "-6", NULL)) {

--- a/src/curlws.h
+++ b/src/curlws.h
@@ -143,6 +143,18 @@ struct cws_config {
      * defaults to the secure validation of host/peer names. */
     int insecure_ok;
 
+    /* If unset this library defaults secure and chooses to apply the best
+     * available TLS depending on the version of curl.
+     *
+     * CURL_SSLVERSION_MAX_DEFAULT [7.54.0 +)
+     * CURL_SSLVERSION_TLSv1_3     [7.52.0 - 7.54.0)
+     * CURL_SSLVERSION_TLSv1_2     [7.50.2 - 7.52.0)
+     *
+     * See the CURLOPT_SSLVERSION details for options you may set here.
+     * https://curl.se/libcurl/c/CURLOPT_SSLVERSION.html
+     */
+    long tls_version;
+
     /* The various websocket protocols in a single string format.
      * Something like "chat", "superchat", "superchat,chat" ...
      * The default is no special protocols (NULL)

--- a/src/internal.h
+++ b/src/internal.h
@@ -64,6 +64,8 @@ struct cfg_set {
 
     /* The request websocket protocols. */
     char *ws_protocols_requested;
+
+    bool follow_redirects;
 };
 
 /* The callback functions used.  These will be called without NULL

--- a/src/receive.c
+++ b/src/receive.c
@@ -78,12 +78,13 @@ static size_t _writefunction_cb(const char *buffer, size_t count, size_t nitems,
     size_t len = count * nitems;
 
     if (priv->cfg.verbose) {
-        fprintf(priv->cfg.verbose_stream, "< websocket bytes received: %ld\n", len);
+        fprintf(priv->cfg.verbose_stream, "< websocket bytes received: %zu\n", len);
     }
 
-    if (priv->header_state.redirection) {
+    if ((priv->cfg.follow_redirects) && (priv->header_state.redirection)) {
         if (priv->cfg.verbose) {
-            fprintf(priv->cfg.verbose_stream, "< websocket bytes ignored due to redirection\n");
+            fprintf(priv->cfg.verbose_stream,
+                        "< websocket bytes ignored due to redirection\n");
         }
         return len;
     }
@@ -92,16 +93,20 @@ static size_t _writefunction_cb(const char *buffer, size_t count, size_t nitems,
         size_t prev_len = len;
 
         if (priv->closed) {
-            return count * nitems;
+            break;
         }
 
         _cws_process_frame(priv, &buffer, &len);
 
         if (len == prev_len) {
-            return count * nitems;
+            break;
         }
     }
 
+    if (priv->cfg.verbose) {
+        fprintf(priv->cfg.verbose_stream,
+                    "< websocket bytes processed: %zu\n", (count * nitems));
+    }
     return count * nitems;
 }
 


### PR DESCRIPTION
In order to debug why the redirection code wasn't working as expected I
needed to change the TLS version to 1.2 so I could debug using
wireshark.  In the process there were several other improvements to
loggin made as well.

  * TLS upgrade/downgrade is working.
  * HTTP redirects are being followed properly & also being ignored properly.

One area not tested is the downgrade to an older version of libcurl.