### PR TITLE
Add a verbose function

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ target_sources(curlws
         send.c
         utils.c
         utf8.c
+        verbose.c
         ws.c
 )
 

--- a/src/receive.c
+++ b/src/receive.c
@@ -32,6 +32,7 @@
 #include "cb.h"
 #include "receive.h"
 #include "utf8.h"
+#include "verbose.h"
 #include "ws.h"
 
 /*----------------------------------------------------------------------------*/
@@ -77,15 +78,10 @@ static size_t _writefunction_cb(const char *buffer, size_t count, size_t nitems,
     CWS *priv = data;
     size_t len = count * nitems;
 
-    if (priv->cfg.verbose) {
-        fprintf(priv->cfg.verbose_stream, "< websocket bytes received: %zu\n", len);
-    }
+    verbose(priv, "< websocket bytes received: %zu\n", len);
 
     if ((priv->cfg.follow_redirects) && (priv->header_state.redirection)) {
-        if (priv->cfg.verbose) {
-            fprintf(priv->cfg.verbose_stream,
-                        "< websocket bytes ignored due to redirection\n");
-        }
+        verbose(priv, "< websocket bytes ignored due to redirection\n");
         return len;
     }
 
@@ -103,10 +99,7 @@ static size_t _writefunction_cb(const char *buffer, size_t count, size_t nitems,
         }
     }
 
-    if (priv->cfg.verbose) {
-        fprintf(priv->cfg.verbose_stream,
-                    "< websocket bytes processed: %zu\n", (count * nitems));
-    }
+    verbose(priv, "< websocket bytes processed: %zu\n", (count * nitems));
     return count * nitems;
 }
 

--- a/src/verbose.c
+++ b/src/verbose.c
@@ -24,9 +24,8 @@
  *
  * https://opensource.org/licenses/MIT
  */
-#include <string.h>
+#include <stdarg.h>
 
-#include "cb.h"
 #include "verbose.h"
 
 /*----------------------------------------------------------------------------*/
@@ -52,109 +51,16 @@
 /*----------------------------------------------------------------------------*/
 /*                             External Functions                             */
 /*----------------------------------------------------------------------------*/
-void cb_on_connect(CWS *priv, const char *protos)
-{
-    verbose(priv, "< websocket on_connect() protos: '%s'\n", protos);
-
-    if (priv->cb.on_connect_fn) {
-        (*priv->cb.on_connect_fn)(priv->cfg.user, priv, protos);
-    }
-
-    verbose(priv, "> websocket on_connect()\n");
-}
-
-
-void cb_on_text(CWS *priv, const char *text, size_t len)
+void verbose(CWS *priv, const char *format, ...)
 {
     if (priv->cfg.verbose) {
-        int truncated;
-        char *dots = "...";
+        va_list args;
 
-        truncated = 40;
-        if (len <= (size_t) truncated) {
-            truncated = (int) len;
-            dots = "";
-        }
-        verbose(priv, "< websocket on_text() len: %zd, text: '%.*s%s'\n", len,
-                truncated, text, dots);
+        va_start(args, format);
+        vfprintf(priv->cfg.verbose_stream, format, args);
+        va_end(args);
     }
-
-    if (priv->cb.on_text_fn) {
-        (*priv->cb.on_text_fn)(priv->cfg.user, priv, text, len);
-    }
-
-    verbose(priv, "> websocket on_text()\n");
 }
-
-
-void cb_on_binary(CWS *priv, const void *buf, size_t len)
-{
-    verbose(priv, "< websocket on_binary() len: %zd, [buf]\n", len);
-
-    if (priv->cb.on_binary_fn) {
-        (*priv->cb.on_binary_fn)(priv->cfg.user, priv, buf, len);
-    }
-
-    verbose(priv, "> websocket on_binary()\n");
-}
-
-
-void cb_on_fragment(CWS *priv, int info, const void *buf, size_t len)
-{
-    verbose(priv, "< websocket on_fragment() info: 0x%08x, len: %zd, [buf]\n", info, len);
-
-    /* Always present since there is a default handler & clients cannot
-     * overwrite using the value NULL as that indicates use the default. */
-    (*priv->cb.on_fragment_fn)(priv->cfg.user, priv, info, buf, len);
-
-    verbose(priv, "> websocket on_fragment()\n");
-}
-
-
-void cb_on_ping(CWS *priv, const void *buf, size_t len)
-{
-    verbose(priv, "< websocket on_ping() len: %zd, [buf]\n", len);
-
-    /* Always present since there is a default handler & clients cannot
-     * overwrite using the value NULL as that indicates use the default. */
-    (*priv->cb.on_ping_fn)(priv->cfg.user, priv, buf, len);
-
-    verbose(priv, "> websocket on_ping()\n");
-}
-
-
-void cb_on_pong(CWS *priv, const void *buf, size_t len)
-{
-    verbose(priv, "< websocket on_pong() len: %zd, [buf]\n", len);
-
-    if (priv->cb.on_pong_fn) {
-        (*priv->cb.on_pong_fn)(priv->cfg.user, priv, buf, len);
-    }
-
-    verbose(priv, "> websocket on_pong()\n");
-}
-
-
-void cb_on_close(CWS *priv, int code, const char *text, size_t len)
-{
-    if (text) {
-        if (SIZE_MAX == len) {
-            len = strlen(text);
-        }
-    } else {
-        len = 0;
-    }
-
-    verbose(priv, "< websocket on_close() code: %d, len: %zd, text: '%.*s'\n",
-            code, len, (int) len, text);
-
-    if (priv->cb.on_close_fn) {
-        (*priv->cb.on_close_fn)(priv->cfg.user, priv, code, text, len);
-    }
-
-    verbose(priv, "> websocket on_close()\n");
-}
-
 
 /*----------------------------------------------------------------------------*/
 /*                             Internal functions                             */

--- a/src/verbose.h
+++ b/src/verbose.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016 Gustavo Sverzut Barbieri
+ * Copyright (c) 2021 Comcast Cable Communications Management, LLC
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * https://opensource.org/licenses/MIT
+ */
+#ifndef __VERBOSE_H__
+#define __VERBOSE_H__
+
+#include "internal.h"
+
+/**
+ * Wrapper helper function to deal with verbosity and outputing that to the
+ * right place.  It's basically printf() with some logic.
+ */
+void verbose(CWS *priv, const char *format, ...);
+
+#endif
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -127,7 +127,9 @@ target_link_libraries (test_data_block_sender cunit)
 # ---------------------------------------------------------------------------- #
 add_test(NAME Test_Handlers COMMAND ${MEMORY_CHECK} ./test_handlers)
 
-add_executable(test_handlers test_handlers.c ../src/cb.c)
+add_executable(test_handlers test_handlers.c
+                             ../src/cb.c
+                             ../src/verbose.c)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 target_link_libraries (test_handlers gcov)
@@ -144,6 +146,7 @@ add_executable(test_receive test_receive.c
                            ../src/cb.c
                            ../src/frame.c
                            ../src/utf8.c
+                           ../src/verbose.c
                            ../src/ws.c)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
@@ -161,6 +164,7 @@ add_executable(test_autobahn_27 test_autobahn_27.c
                                 ../src/cb.c
                                 ../src/frame.c
                                 ../src/utf8.c
+                                ../src/verbose.c
                                 ../src/ws.c)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
@@ -175,7 +179,9 @@ target_link_libraries (test_autobahn_27)
 # ---------------------------------------------------------------------------- #
 add_test(NAME Test_Send COMMAND ${MEMORY_CHECK} ./test_send)
 
-add_executable(test_send test_send.c ../src/frame.c)
+add_executable(test_send test_send.c
+                         ../src/frame.c
+                         ../src/verbose.c)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 target_link_libraries (test_send gcov)
@@ -190,7 +196,8 @@ add_test(NAME Test_Header COMMAND ${MEMORY_CHECK} ./test_header)
 
 add_executable(test_header test_header.c
                            ../src/cb.c
-                           ../src/utils.c)
+                           ../src/utils.c
+                           ../src/verbose.c)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 target_link_libraries (test_header gcov)
@@ -225,6 +232,7 @@ add_executable(test_curlws test_curlws.c
                            ${SHA_FILES}
                            ../src/utf8.c
                            ../src/utils.c
+                           ../src/verbose.c
                            ../src/ws.c)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
@@ -286,6 +294,7 @@ add_executable(test_autobahn autobahn-testee.c
                              ${SHA_FILES}
                              ../src/utf8.c
                              ../src/utils.c
+                             ../src/verbose.c
                              ../src/ws.c)
 
 
@@ -317,6 +326,7 @@ add_executable(test_autobahn_parallel autobahn-testee-parallel.c
                                       ${SHA_FILES}
                                       ../src/utf8.c
                                       ../src/utils.c
+                                      ../src/verbose.c
                                       ../src/ws.c)
 
 
@@ -342,6 +352,7 @@ add_executable(autobahn_report autobahn_report.c
                                       ${SHA_FILES}
                                       ../src/utf8.c
                                       ../src/utils.c
+                                      ../src/verbose.c
                                       ../src/ws.c)
 
 


### PR DESCRIPTION
It turns out that there are a fair number of verbose logs that need to
be printed.  It is time to add a printf() style verbose function to
elminate a bunch of duplicate checks all over the code.