### PR TITLE
Refactor the close code per websocket spec

### DIFF
--- a/src/curlws.c
+++ b/src/curlws.c
@@ -44,6 +44,7 @@
 #include "sha1.h"
 #include "utils.h"
 #include "utf8.h"
+#include "verbose.h"
 #include "ws.h"
 
 /*----------------------------------------------------------------------------*/
@@ -264,7 +265,10 @@ CWScode cws_close(CWS *priv, int code, const char *reason, size_t len)
     }
 
     rv = frame_sender_control(priv, options, p, len);
-    priv->closed = true;
+    if (!(CLOSE_QUEUED & priv->close_state)) {
+        priv->close_state |= CLOSE_QUEUED;
+        verbose_close(priv);
+    }
     return rv;
 }
 

--- a/src/data_block_sender.c
+++ b/src/data_block_sender.c
@@ -68,7 +68,7 @@ CWScode data_block_sender(CWS *priv, int options, const void *data, size_t len)
             return CWSE_INVALID_OPTIONS;
     }
 
-    if (priv->closed) {
+    if (priv->close_state) {
         return CWSE_CLOSED_CONNECTION;
     }
 

--- a/src/frame_senders.c
+++ b/src/frame_senders.c
@@ -83,7 +83,7 @@ CWScode frame_sender_control(CWS *priv, int options, const void *data, size_t le
             return CWSE_INVALID_OPTIONS;
     }
 
-    if ((CLOSE_QUEUED & priv->close_state)) {
+    if (CLOSE_QUEUED & priv->close_state) {
         return CWSE_CLOSED_CONNECTION;
     }
 

--- a/src/frame_senders.c
+++ b/src/frame_senders.c
@@ -83,7 +83,7 @@ CWScode frame_sender_control(CWS *priv, int options, const void *data, size_t le
             return CWSE_INVALID_OPTIONS;
     }
 
-    if (priv->closed) {
+    if ((CLOSE_QUEUED & priv->close_state)) {
         return CWSE_CLOSED_CONNECTION;
     }
 
@@ -149,7 +149,7 @@ CWScode frame_sender_data(CWS *priv, int options, const void *data, size_t len)
             return CWSE_INVALID_OPTIONS;
     }
 
-    if (priv->closed) {
+    if (priv->close_state) {
         return CWSE_CLOSED_CONNECTION;
     }
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -42,6 +42,13 @@
 /*----------------------------------------------------------------------------*/
 #define IGNORE_UNUSED(x) (void) x
 
+#define CLOSE_RECEIVED      0x0010
+#define CLOSE_QUEUED        0x0020
+#define CLOSE_SENT          0x0040
+#define CLOSED              0x0080
+#define READY_TO_CLOSE(x)   \
+    ((CLOSE_SENT|CLOSE_RECEIVED) == ((CLOSED|CLOSE_SENT|CLOSE_RECEIVED) & x))
+
 /*----------------------------------------------------------------------------*/
 /*                               Data Structures                              */
 /*----------------------------------------------------------------------------*/
@@ -161,12 +168,12 @@ struct cws_object {
 
     /* Connection State flags */
     uint8_t dispatching;
-    uint8_t pause_flags;
+    int pause_flags;
 
     /* The header state structure */
     struct header_map header_state;
 
-    bool closed;
+    int close_state;
 };
 
 /*----------------------------------------------------------------------------*/

--- a/src/verbose.c
+++ b/src/verbose.c
@@ -62,6 +62,22 @@ void verbose(CWS *priv, const char *format, ...)
     }
 }
 
+
+void verbose_close(CWS *priv)
+{
+    if (!priv->close_state) {
+        verbose(priv, "[ websocket connection state: active ]\n");
+    } else if ((CLOSED|CLOSE_SENT|CLOSE_QUEUED|CLOSE_RECEIVED) == priv->close_state) {
+        verbose(priv, "[ websocket connection state: (closed)   closed  sent  queued  received ]\n");
+    } else {
+        verbose(priv, "[ websocket connection state: (closing) %cclosed %csent %cqueued %creceived ]\n",
+                (CLOSED         & priv->close_state) ? ' ' : '!',
+                (CLOSE_SENT     & priv->close_state) ? ' ' : '!',
+                (CLOSE_QUEUED   & priv->close_state) ? ' ' : '!',
+                (CLOSE_RECEIVED & priv->close_state) ? ' ' : '!' );
+    }
+}
+
 /*----------------------------------------------------------------------------*/
 /*                             Internal functions                             */
 /*----------------------------------------------------------------------------*/

--- a/src/verbose.h
+++ b/src/verbose.h
@@ -35,5 +35,9 @@
  */
 void verbose(CWS *priv, const char *format, ...);
 
+/**
+ * Print out the close status of the connection.
+ */
+void verbose_close(CWS *priv);
 #endif
 

--- a/tests/test_autobahn_27.c
+++ b/tests/test_autobahn_27.c
@@ -45,6 +45,15 @@ CURLcode curl_easy_setopt(CURL *easy, CURLoption option, ... )
     return CURLE_OK;
 }
 
+
+CURLcode curl_easy_pause(CURL *easy, int bitmask)
+{
+    (void) easy;
+    (void) bitmask;
+    return CURLE_OK;
+}
+
+
 struct mock_ping {
     const char *data;
     size_t len;

--- a/tests/test_data_block_sender.c
+++ b/tests/test_data_block_sender.c
@@ -77,10 +77,10 @@ void test_data_block_sender()
     CU_ASSERT(CWSE_INVALID_OPTIONS == data_block_sender(&priv, CWS_BINARY|CWS_TEXT, NULL, 0));
     CU_ASSERT(CWSE_INVALID_OPTIONS == data_block_sender(&priv, CWS_TEXT|CWS_FIRST, NULL, 0));
 
-    priv.closed = true;
+    priv.close_state = CLOSED;
     CU_ASSERT(CWSE_CLOSED_CONNECTION == data_block_sender(&priv, CWS_TEXT, NULL, 0));
 
-    priv.closed = false;
+    priv.close_state = 0;
     do {
         struct mock vector = {
             .rv = CWSE_OK,

--- a/tests/test_frame_senders.c
+++ b/tests/test_frame_senders.c
@@ -74,10 +74,10 @@ void test_frame_sender_control()
     CU_ASSERT(CWSE_INVALID_OPTIONS == frame_sender_control(&priv, -1, NULL, 0));
     CU_ASSERT(CWSE_INVALID_OPTIONS == frame_sender_control(&priv, CWS_PING|CWS_PONG, NULL, 0));
 
-    priv.closed = true;
+    priv.close_state = CLOSE_QUEUED;
     CU_ASSERT(CWSE_CLOSED_CONNECTION == frame_sender_control(&priv, CWS_PING, NULL, 0));
 
-    priv.closed = false;
+    priv.close_state = 0;
     CU_ASSERT(CWSE_APP_DATA_LENGTH_TOO_LONG == frame_sender_control(&priv, CWS_PING, "ignore", 1000));
 
     /* Valid, but empty payloads. */
@@ -113,10 +113,10 @@ void test_frame_sender_data()
     CU_ASSERT(CWSE_INVALID_OPTIONS == frame_sender_data(&priv, -1, NULL, 0));
     CU_ASSERT(CWSE_INVALID_OPTIONS == frame_sender_data(&priv, CWS_CONT|CWS_TEXT, NULL, 0));
 
-    priv.closed = true;
+    priv.close_state = CLOSE_QUEUED;
     CU_ASSERT(CWSE_CLOSED_CONNECTION == frame_sender_data(&priv, CWS_TEXT|CWS_FIRST, NULL, 0));
 
-    priv.closed = false;
+    priv.close_state = 0;
     CU_ASSERT(CWSE_STREAM_CONTINUITY_ISSUE == frame_sender_data(&priv, CWS_CONT, "ignore", 5));
 
     CU_ASSERT(CWSE_INVALID_OPTIONS == frame_sender_data(&priv, CWS_CONT|CWS_FIRST, "ignore", 5));

--- a/tests/test_receive.c
+++ b/tests/test_receive.c
@@ -45,6 +45,14 @@ CURLcode curl_easy_setopt(CURL *easy, CURLoption option, ... )
 }
 
 
+CURLcode curl_easy_pause(CURL *easy, int bitmask)
+{
+    (void) easy;
+    (void) bitmask;
+    return CURLE_OK;
+}
+
+
 struct mock_cws_close {
     int code;
     const char *reason;
@@ -63,7 +71,7 @@ CWScode cws_close(CWS *priv, int code, const char *reason, size_t len)
 
     if (__cws_close_goal) {
         CU_ASSERT(NULL != priv);
-        priv->closed = true;
+        priv->close_state = CLOSE_QUEUED;
         CU_ASSERT(__cws_close_goal->code == code);
         CU_ASSERT(__cws_close_goal->len == len);
         /* Make sure the string lengths actually are the same ... */


### PR DESCRIPTION
This change enables the code to ensure a close frame is sent and
received, then after both, the connection is closed.  Due to the likely
ongoing debugging needed a verbose_close() call was made to simplfy the
output of the connection state.

Overall this works with a real test server and also works when the cord
is pulled from the connection (a 56 after a timeout occurs).