### PR TITLE
Add return codes to the callbacks

### DIFF
--- a/examples/cli/cli.c
+++ b/examples/cli/cli.c
@@ -62,10 +62,10 @@ static void main_loop(CWS*, CURLM*);
 static bool is_opt(const char*, const char*, const char*);
 
 static CURLcode configure(void*, CWS*, CURL*);
-static void on_connect(void*, CWS*, const char*);
-static void on_text(void*, CWS*, const char*, size_t);
-static void on_binary(void*, CWS*, const void*, size_t);
-static void on_close(void*, CWS*, int, const char*, size_t);
+static int on_connect(void*, CWS*, const char*);
+static int on_text(void*, CWS*, const char*, size_t);
+static int on_binary(void*, CWS*, const void*, size_t);
+static int on_close(void*, CWS*, int, const char*, size_t);
 
 /*----------------------------------------------------------------------------*/
 /*                             External Functions                             */
@@ -295,28 +295,32 @@ static bool is_opt(const char *in, const char *s1, const char *s2)
 
 
 /* The custom on_connect handler for this instance of the websocket code. */
-static void on_connect(void *user, CWS *ws, const char *protos)
+static int on_connect(void *user, CWS *ws, const char *protos)
 {
     printf("on_connect(user, ws, '%s')\n", (NULL == protos) ? "" : protos );
     (void) user;
     (void) ws;
 
     /* TODO: ADD YOUR CODE HERE! */
+
+    return 0;
 }
 
 /* The custom on_text handler for this instance of the websocket code. */
-static void on_text(void *user, CWS *ws, const char *text, size_t len)
+static int on_text(void *user, CWS *ws, const char *text, size_t len)
 {
     printf("on_text(user, ws, '%.*s', %zd)\n", (int) len, text, len);
     (void) user;
     (void) ws;
 
     /* TODO: ADD YOUR CODE HERE! */
+
+    return 0;
 }
 
 
 /* The custom on_binary handler for this instance of the websocket code. */
-static void on_binary(void *user, CWS *ws, const void *buf, size_t len)
+static int on_binary(void *user, CWS *ws, const void *buf, size_t len)
 {
     printf("on_binary(user, ws, buf, %zd)\n", len);
     (void) user;
@@ -324,17 +328,21 @@ static void on_binary(void *user, CWS *ws, const void *buf, size_t len)
     (void) buf;
 
     /* TODO: ADD YOUR CODE HERE! */
+
+    return 0;
 }
 
 
 /* The custom on_close handler for this instance of the websocket code. */
-static void on_close(void *user, CWS *ws, int code, const char *reason, size_t len)
+static int on_close(void *user, CWS *ws, int code, const char *reason, size_t len)
 {
     printf("on_close(user, ws, %d, '%.*s', %zd)\n", code, (int) len, reason, len);
     (void) user;
     (void) ws;
 
     /* TODO: ADD YOUR CODE HERE! */
+
+    return 0;
 }
 
 

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -51,8 +51,8 @@
 /*----------------------------------------------------------------------------*/
 /*                             Function Prototypes                            */
 /*----------------------------------------------------------------------------*/
-static void _default_on_fragment(void*, CWS*, int, const void*, size_t);
-static void _default_on_ping(void*, CWS*, const void*, size_t);
+static int _default_on_fragment(void*, CWS*, int, const void*, size_t);
+static int _default_on_ping(void*, CWS*, const void*, size_t);
 
 /*----------------------------------------------------------------------------*/
 /*                             External Functions                             */
@@ -93,7 +93,7 @@ void populate_callbacks(struct callbacks *dest, const struct cws_config *src)
 
 /*----------------------------------------------------------------------------*/
 
-static void _default_on_fragment(void *user, CWS *priv, int info, const void *buffer, size_t len)
+static int _default_on_fragment(void *user, CWS *priv, int info, const void *buffer, size_t len)
 {
     int one_frame = (CWS_FIRST | CWS_LAST);
 
@@ -134,13 +134,17 @@ static void _default_on_fragment(void *user, CWS *priv, int info, const void *bu
             priv->stream_buffer_len = 0;
         }
     }
+
+    return 0;
 }
 
 
 
-static void _default_on_ping(void *user, CWS *priv, const void *buffer, size_t len)
+static int _default_on_ping(void *user, CWS *priv, const void *buffer, size_t len)
 {
     IGNORE_UNUSED(user);
 
     cws_pong(priv, buffer, len);
+
+    return 0;
 }

--- a/src/internal.h
+++ b/src/internal.h
@@ -78,13 +78,13 @@ struct cfg_set {
 /* The callback functions used.  These will be called without NULL
  * checking as the library expects to use default values. */
 struct callbacks {
-    void (*on_connect_fn)(void*, CWS*, const char*);
-    void (*on_text_fn)(void*, CWS*, const char*, size_t);
-    void (*on_binary_fn)(void*, CWS*, const void*, size_t);
-    void (*on_fragment_fn)(void*, CWS*, int, const void*, size_t);
-    void (*on_ping_fn)(void*, CWS*, const void*, size_t);
-    void (*on_pong_fn)(void*, CWS*, const void*, size_t);
-    void (*on_close_fn)(void*, CWS*, int, const char*, size_t);
+    int (*on_connect_fn)(void*, CWS*, const char*);
+    int (*on_text_fn)(void*, CWS*, const char*, size_t);
+    int (*on_binary_fn)(void*, CWS*, const void*, size_t);
+    int (*on_fragment_fn)(void*, CWS*, int, const void*, size_t);
+    int (*on_ping_fn)(void*, CWS*, const void*, size_t);
+    int (*on_pong_fn)(void*, CWS*, const void*, size_t);
+    int (*on_close_fn)(void*, CWS*, int, const char*, size_t);
 };
 
 struct recv {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,7 +129,8 @@ add_test(NAME Test_Handlers COMMAND ${MEMORY_CHECK} ./test_handlers)
 
 add_executable(test_handlers test_handlers.c
                              ../src/cb.c
-                             ../src/verbose.c)
+                             ../src/verbose.c
+                             ../src/ws.c)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 target_link_libraries (test_handlers gcov)
@@ -197,7 +198,8 @@ add_test(NAME Test_Header COMMAND ${MEMORY_CHECK} ./test_header)
 add_executable(test_header test_header.c
                            ../src/cb.c
                            ../src/utils.c
-                           ../src/verbose.c)
+                           ../src/verbose.c
+                           ../src/ws.c)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 target_link_libraries (test_header gcov)

--- a/tests/autobahn-testee.c
+++ b/tests/autobahn-testee.c
@@ -251,20 +251,21 @@ static bool check_utf8(const char *text) {
     return true;
 }
 
-static void on_connect(void *data, CWS *ws, const char *websocket_protocols) {
+static int on_connect(void *data, CWS *ws, const char *websocket_protocols) {
     INF("connected, websocket_protocols='%s'", websocket_protocols);
     (void)data;
     (void)ws;
+
+    return 0;
 }
 
-static void on_text(void *data, CWS *ws, const char *text, size_t len) {
+static int on_text(void *data, CWS *ws, const char *text, size_t len) {
     if (0 < len) {
         char *tmp = (char*) malloc(len+1);
         memcpy(tmp, text, len);
         tmp[len] = '\0';
         if (!check_utf8(tmp)) {
-            cws_close(ws, 1007, "invalid UTF-8", SIZE_MAX);
-            return;
+            return 1007;
         }
         free(tmp);
     }
@@ -272,9 +273,10 @@ static void on_text(void *data, CWS *ws, const char *text, size_t len) {
     INF("TEXT %zd bytes={ '%s' }", len, text);
     cws_send_blk_text(ws, text, len);
     (void)data;
+    return 0;
 }
 
-static void on_binary(void *data, CWS *ws, const void *mem, size_t len) {
+static int on_binary(void *data, CWS *ws, const void *mem, size_t len) {
     const uint8_t *bytes = mem;
     size_t i;
 
@@ -292,21 +294,27 @@ static void on_binary(void *data, CWS *ws, const void *mem, size_t len) {
 
     cws_send_blk_binary(ws, mem, len);
     (void)data;
+
+    return 0;
 }
 
-static void on_ping(void *data, CWS *ws, const void *reason, size_t len) {
+static int on_ping(void *data, CWS *ws, const void *reason, size_t len) {
     INF("PING %zd bytes='%.*s'", len, (int) len, (const char*) reason);
     cws_pong(ws, reason, len);
     (void)data;
+
+    return 0;
 }
 
-static void on_pong(void *data, CWS *ws, const void *reason, size_t len) {
+static int on_pong(void *data, CWS *ws, const void *reason, size_t len) {
     INF("PONG %zd bytes='%.*s'", len, (int) len, (const char*) reason);
     (void)data;
     (void)ws;
+
+    return 0;
 }
 
-static void on_close(void *data, CWS *ws, int reason, const char *reason_text, size_t len) {
+static int on_close(void *data, CWS *ws, int reason, const char *reason_text, size_t len) {
     struct myapp_ctx *ctx = data;
 
     INF("CLOSE=%4d %zd bytes '%s'", reason, len, reason_text);
@@ -318,10 +326,11 @@ static void on_close(void *data, CWS *ws, int reason, const char *reason_text, s
         tmp[len] = '\0';
         if (!check_utf8(reason_text)) {
             cws_close(ws, 1007, "invalid UTF-8", SIZE_MAX);
-            return;
+            return 0;
         }
         free(tmp);
     }
+    return 0;
 }
 
 int main(int argc, char *argv[]) {

--- a/tests/test_autobahn_27.c
+++ b/tests/test_autobahn_27.c
@@ -64,7 +64,7 @@ struct mock_ping {
 
 
 static struct mock_ping *__on_ping_goal = NULL;
-static void on_ping(void *data, CWS *handle, const void *buffer, size_t len)
+static int on_ping(void *data, CWS *handle, const void *buffer, size_t len)
 {
     (void) data;
 
@@ -80,6 +80,8 @@ static void on_ping(void *data, CWS *handle, const void *buffer, size_t len)
     }
     __on_ping_goal->seen++;
     __on_ping_goal = __on_ping_goal->next;
+
+    return 0;
 }
 
 

--- a/tests/test_header.c
+++ b/tests/test_header.c
@@ -72,20 +72,35 @@ CURLcode curl_easy_getinfo(CURL *easy, CURLINFO info, ... )
     return CURLE_OK;
 }
 
-void on_connect(void *data, CWS *priv, const char *websocket_protocols)
+CWScode cws_close(CWS *handle, int code, const char *reason, size_t len)
+{
+    IGNORE_UNUSED(handle);
+    IGNORE_UNUSED(code);
+    IGNORE_UNUSED(reason);
+    IGNORE_UNUSED(len);
+
+    return CWSE_OK;
+}
+
+
+int on_connect(void *data, CWS *priv, const char *websocket_protocols)
 {
     (void) data;
     (void) priv;
     (void) websocket_protocols;
+
+    return 0;
 }
 
-void on_close(void *data, CWS *priv, int code, const char *reason, size_t len)
+int on_close(void *data, CWS *priv, int code, const char *reason, size_t len)
 {
     (void) data;
     (void) priv;
     (void) code;
     (void) reason;
     (void) len;
+
+    return 0;
 }
 
 void _cws_cleanup(CWS *priv)

--- a/tests/test_receive.c
+++ b/tests/test_receive.c
@@ -115,7 +115,7 @@ struct mock_stream {
 };
 
 static struct mock_stream *__on_fragment_goal = NULL;
-static void on_fragment(void *data, CWS *handle, int info, const void *buffer, size_t len)
+static int on_fragment(void *data, CWS *handle, int info, const void *buffer, size_t len)
 {
     (void) data;
 
@@ -153,6 +153,8 @@ static void on_fragment(void *data, CWS *handle, int info, const void *buffer, s
             __on_fragment_goal = NULL;
         }
     }
+
+    return 0;
 }
 
 
@@ -165,7 +167,7 @@ struct mock_close {
 };
 
 static struct mock_close *__on_close_goal = NULL;
-static void on_close(void *data, CWS *handle, int code, const char *reason, size_t len)
+static int on_close(void *data, CWS *handle, int code, const char *reason, size_t len)
 {
     (void) data;
 
@@ -196,6 +198,8 @@ static void on_close(void *data, CWS *handle, int code, const char *reason, size
             __on_close_goal = NULL;
         }
     }
+
+    return 0;
 }
 
 
@@ -207,7 +211,7 @@ struct mock_ping {
 };
 
 static struct mock_ping *__on_ping_goal = NULL;
-static void on_ping(void *data, CWS *handle, const void *buffer, size_t len)
+static int on_ping(void *data, CWS *handle, const void *buffer, size_t len)
 {
     (void) data;
 
@@ -228,6 +232,8 @@ static void on_ping(void *data, CWS *handle, const void *buffer, size_t len)
             __on_ping_goal = NULL;
         }
     }
+
+    return 0;
 }
 
 
@@ -239,7 +245,7 @@ struct mock_pong {
 };
 
 static struct mock_pong *__on_pong_goal = NULL;
-static void on_pong(void *data, CWS *handle, const void *buffer, size_t len)
+static int on_pong(void *data, CWS *handle, const void *buffer, size_t len)
 {
     (void) data;
 
@@ -260,6 +266,8 @@ static void on_pong(void *data, CWS *handle, const void *buffer, size_t len)
             __on_pong_goal = NULL;
         }
     }
+
+    return 0;
 }
 
 


### PR DESCRIPTION
Allow clients to close streams at the end of a callback if they wish.
This allows for more flexibility in the future for the API and it's
users.