### PR TITLE
Rename the callbacks used with curl

### DIFF
--- a/src/receive.c
+++ b/src/receive.c
@@ -55,7 +55,7 @@
 /*----------------------------------------------------------------------------*/
 /*                             Function Prototypes                            */
 /*----------------------------------------------------------------------------*/
-static size_t _writefunction_cb(const char*, size_t, size_t, void*);
+static size_t _receive_cb(const char*, size_t, size_t, void*);
 static void _cws_process_frame(CWS*, const char**, size_t*);
 static void _error_close(CWS *priv, int, const char*, size_t);
 static inline size_t _min_size_t(size_t, size_t);
@@ -67,7 +67,7 @@ CURLcode receive_init(CWS *priv)
 {
     CURLcode rv;
 
-    rv  = curl_easy_setopt(priv->easy, CURLOPT_WRITEFUNCTION, _writefunction_cb);
+    rv  = curl_easy_setopt(priv->easy, CURLOPT_WRITEFUNCTION, _receive_cb);
     rv |= curl_easy_setopt(priv->easy, CURLOPT_WRITEDATA, priv);
 
     return rv;
@@ -80,7 +80,7 @@ CURLcode receive_init(CWS *priv)
 /**
  * This is the callback used by curl.
  */
-static size_t _writefunction_cb(const char *buffer, size_t count, size_t nitems, void *data)
+static size_t _receive_cb(const char *buffer, size_t count, size_t nitems, void *data)
 {
     CWS *priv = data;
     size_t len = count * nitems;

--- a/src/send.c
+++ b/src/send.c
@@ -64,7 +64,7 @@ struct cws_buf_queue {
 /*----------------------------------------------------------------------------*/
 /*                             Function Prototypes                            */
 /*----------------------------------------------------------------------------*/
-static size_t _readfunction_cb(char*, size_t, size_t, void*);
+static size_t _send_cb(char*, size_t, size_t, void*);
 
 /*----------------------------------------------------------------------------*/
 /*                             External Functions                             */
@@ -74,7 +74,7 @@ CURLcode send_init(CWS *priv)
 {
     CURLcode rv;
 
-    rv  = curl_easy_setopt(priv->easy, CURLOPT_READFUNCTION, _readfunction_cb);
+    rv  = curl_easy_setopt(priv->easy, CURLOPT_READFUNCTION, _send_cb);
     rv |= curl_easy_setopt(priv->easy, CURLOPT_READDATA, priv);
 
     return rv;
@@ -241,7 +241,7 @@ static size_t _fill_outgoing_buffer(CWS *priv, char *buffer, size_t len)
  *
  * @return the number of bytes provided or CURL_READFUNC_PAUSE
  */
-static size_t _readfunction_cb(char *buffer, size_t count, size_t n, void *data)
+static size_t _send_cb(char *buffer, size_t count, size_t n, void *data)
 {
     CWS *priv = data;
     size_t len = count * n;

--- a/tests/test_autobahn_27.c
+++ b/tests/test_autobahn_27.c
@@ -198,7 +198,7 @@ void test_27()
 
     p = in;
     for (size_t i = 0; i < sizeof(list)/sizeof(size_t); i++) {
-        if (list[i] != _writefunction_cb(p, list[i], 1, &priv)) {
+        if (list[i] != _receive_cb(p, list[i], 1, &priv)) {
             printf("Failed to accept the bytes.\n");
         }
         p += list[i];

--- a/tests/test_receive.c
+++ b/tests/test_receive.c
@@ -315,7 +315,7 @@ void run_test( struct test_vector *v )
 
     p = v->in;
     for (size_t i = 0; i < v->block_count; i++) {
-        size_t rv = _writefunction_cb(p, v->blocks[i], 1, &priv);
+        size_t rv = _receive_cb(p, v->blocks[i], 1, &priv);
 
         if (rv != v->rv[i]) {
             printf("%s - '%.*s' byte count: %d got: %zd\n", v->test_name,

--- a/tests/test_send.c
+++ b/tests/test_send.c
@@ -129,13 +129,13 @@ void test_simple()
 
     /* Ignore redirection */
     priv.header_state.redirection = true;
-    CU_ASSERT(40 == _readfunction_cb((char*) buffer, 40, 1, &priv));
+    CU_ASSERT(40 == _send_cb((char*) buffer, 40, 1, &priv));
     priv.header_state.redirection = false;
 
     /* Test the empty send queue --> pause things behavior */
     CU_ASSERT(NULL == priv.send);
     CU_ASSERT(0 == priv.pause_flags);
-    CU_ASSERT(CURL_READFUNC_PAUSE == _readfunction_cb((char*) buffer, 40, 1, &priv));
+    CU_ASSERT(CURL_READFUNC_PAUSE == _send_cb((char*) buffer, 40, 1, &priv));
     CU_ASSERT(CURLPAUSE_SEND == priv.pause_flags);
 
     /* Send 2 frames in a large enough buffer - starting from paused state */
@@ -143,7 +143,7 @@ void test_simple()
     CU_ASSERT(CWSE_OK == send_frame(&priv, &f[0]));
     CU_ASSERT(CWSE_OK == send_frame(&priv, &f[1]));
     CU_ASSERT(CWSE_OK == send_frame(&priv, &f[2]));
-    CU_ASSERT(31 == _readfunction_cb((char*) buffer, 40, 1, &priv));
+    CU_ASSERT(31 == _send_cb((char*) buffer, 40, 1, &priv));
 
     for (size_t i = 0; i < sizeof(expect); i++) {
         CU_ASSERT(expect[i] == buffer[i]);
@@ -186,7 +186,7 @@ void test_small_buffer()
     setup_test(&priv);
 
     CU_ASSERT(CWSE_OK == send_frame(&priv, &f[0]));
-    CU_ASSERT(10 == _readfunction_cb((char*) buffer, 10, 1, &priv));
+    CU_ASSERT(10 == _send_cb((char*) buffer, 10, 1, &priv));
 
     for (size_t i = 0; i < sizeof(expect); i++) {
         CU_ASSERT(expect[i] == buffer[i]);


### PR DESCRIPTION
Instead of using the callback name that curl calls the functions, make
them more meaningful to this library.