### PR TITLE
Improve library versioning

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           export OLD_VERSION=$(git describe --tags `git rev-list --tags --max-count=1` | tail -1)
           export TAG=$(cat CHANGELOG.md | perl -0777 -ne 'print "$1" if /.*## \[Unreleased\]\s+## \[(v\d+.\d+.\d+)\].*/s')
-          export BINVER=$(cat CMakeLists.txt | perl -0777 -ne 'print "v$1" if /.*set\s*\(\s*VERSION\s*\"(\d+.\d+.\d+)\".*\)/s')
+          export BINVER=$(cat CMakeLists.txt | perl -0777 -ne 'print "v$1" if /.*project\s*\(.*\s*VERSION\s*(\d+.\d+.\d+).*\s*\)/s')
           export TODAY=`date +'%m/%d/%Y'`
           export NOTES=$(cat CHANGELOG.md | perl -0777 -ne 'print "$ENV{TODAY}\n\n$1\n" if /.*## \[$ENV{TAG}\]\s(.*?)\s+## \[(v\d+.\d+.\d+)\].*/s')
           if [[ "$TAG" != "" && "$TAG" != "$BINVER" ]]; then echo "CHANGELOG.md($TAG) and CMakeLists.txt VERSION($BINVER) do not match"; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: 2021 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: MIT
 
-project(curlws)
 cmake_minimum_required(VERSION 3.13)
-set(VERSION "1.0.1")
+
+project(curlws VERSION 1.0.2)
+
+math(EXPR curlws_BITWISE_VERSION "${curlws_VERSION_MAJOR} << 16 | ${curlws_VERSION_MINOR} << 8 | ${curlws_VERSION_PATCH}" OUTPUT_FORMAT HEXADECIMAL)
 
 add_definitions(-std=c99)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wall -Wpedantic")
@@ -27,7 +29,7 @@ endif()
 # Find the required libcurl library and headers
 #
 include(FindPkgConfig)
-pkg_check_modules(CURL libcurl REQUIRED)
+pkg_check_modules(CURL libcurl REQUIRED libcurl>=7.50.2)
 include_directories(
   SYSTEM ${CURL_INCLUDE_DIRS}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,9 @@ target_sources(curlws
         ws.c
 )
 
+configure_file(curlwsver.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/curlwsver.h)
+
 if (USE_OPENSSL_SHA)
     MESSAGE(STATUS "Using Openssl for SHA1")
     target_sources(curlws
@@ -40,12 +43,12 @@ else()
 endif()
 
 install (FILES
+         ${CMAKE_CURRENT_BINARY_DIR}/curlwsver.h
          ${CMAKE_CURRENT_SOURCE_DIR}/curlws.h
          DESTINATION include/curlws)
 
 set_target_properties(curlws PROPERTIES
-        OUTPUT_NAME curlws
-        SOVERSION ${VERSION})
+        OUTPUT_NAME curlws)
 
 install(TARGETS curlws
         RUNTIME DESTINATION bin

--- a/src/curlwsver.h.in
+++ b/src/curlwsver.h.in
@@ -1,0 +1,31 @@
+#
+# SPDX-FileCopyrightText: 2016 Gustavo Sverzut Barbieri
+# SPDX-FileCopyrightText: 2021 Comcast Cable Communications Management, LLC
+#
+# SPDX-License-Identifier: MIT
+#
+
+#ifndef _CURLWS_VERSION_H_
+#define _CURLWS_VERSION_H_ 1
+
+#define CURLWS_VERSION          "@curlws_VERSION@"
+
+#define CURLWS_VERSION_MAJOR    @curlws_VERSION_MAJOR@
+#define CURLWS_VERSION_MINOR    @curlws_VERSION_MINOR@
+#define CURLWS_VERSION_PATCH    @curlws_VERSION_PATCH@
+
+/* This is the numeric version of the curlws version number, meant for easier
+ * parsing and comparisons by programs.  The CURLWS_VERSION_NUM define will
+ * always follow this syntax:
+ *
+ *      0xAABBCC
+ *
+ * Where AA, BB, and CC are each major version, minor version, patch in hex
+ * using 10 bits each.
+ *
+ * It should be safe to compare two different versions with the greater number
+ * being the newer version.
+ */
+#define CURLWS_VERSION_NUM      @curlws_BITWISE_VERSION@
+
+#endif


### PR DESCRIPTION
 - Changed the versioning to be for the project, not the .so file.
 - Updated the Github tag workflow to validate that the CHANGELOG.md and
   the cmake project version are the same.

Fixes Issue #59 