### PR TITLE
Directly apply the length instead of calling strlen function

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -68,8 +68,8 @@ bool cws_has_prefix(const char *s, size_t len, const char *prefix)
 
 char *cws_rewrite_url(const char *url)
 {
-    size_t ws_len  = strlen("ws://");
-    size_t wss_len = strlen("wss://");
+    size_t ws_len  = 5;
+    size_t wss_len = 6;
     size_t url_len = strlen(url);
     char *rv;
 


### PR DESCRIPTION
Hello,
In `utils.c` at lines `71` and `72` to know the length of `ws://` and `wss://` instead of using `strlen(...)`, we can just directly use the known length values. Compilers may just do it for us at compile-time but doing it explicitly is just better in here.